### PR TITLE
PHP 8 compatibility

### DIFF
--- a/Project/CMS/Administrator/index.php
+++ b/Project/CMS/Administrator/index.php
@@ -1,6 +1,6 @@
 <?php
 
-ini_set('display_errors', 1);
+ini_set('display_errors', 0);
 require '../../../vendor/autoload.php';
 define("SIDE", '/Administrator');
 

--- a/Project/CMS/Administrator/index.php
+++ b/Project/CMS/Administrator/index.php
@@ -1,19 +1,21 @@
 <?php
 
-ini_set('display_errors', 0);
+ini_set('display_errors', 1);
 require '../../../vendor/autoload.php';
 define("SIDE", '/Administrator');
 
 if (file_exists('../config.php')) {
     include('../config.php');
-	define("HASH", $prefix_table);
+    define("HASH", $prefix_table);
 } else {
     die('The config file dosen\'t exist !');
 }
 
-if(!empty($timezone)){ date_default_timezone_set($timezone); }
+if (!empty($timezone)) {
+    date_default_timezone_set($timezone);
+}
 $session_domain = !empty($session_domain) ? $session_domain : $_SERVER['SERVER_NAME'];
-$session_time = !empty($session_time) ? $session_time : '0';
+$session_time = !empty($session_time) ? (int)$session_time : 0;
 $session_path = !empty($session_path) ? $session_path : '/';
 session_set_cookie_params($session_time, $session_path, $session_domain);
 session_start();
@@ -25,7 +27,12 @@ $_SESSION['lang'] = isset($_SESSION['lang']) ? $_SESSION['lang'] : "en";
 
 $container = new stdClass();
 // Connexion and Data
-$container->system_connexion = new \CMS\Administrator\Functions\Database\Database($al_db_name, $al_user, $al_password, $al_host);
+$container->system_connexion = new \CMS\Administrator\Functions\Database\Database(
+    $al_db_name,
+    $al_user,
+    $al_password,
+    $al_host
+);
 $container->data = new \CMS\Libraries\Classes\Container\Data($container);
 
 // Load libraries

--- a/Project/CMS/Libraries/Classes/Container/Data.php
+++ b/Project/CMS/Libraries/Classes/Container/Data.php
@@ -9,7 +9,7 @@ class Data {
     public function __construct($container) {
         $this->db = $container->system_connexion->database();
     }
-	
+
 	public function setArrayInsert($array) {
 		$table = array();
 		foreach($array as $key => $value){
@@ -32,13 +32,13 @@ class Data {
 		$query->execute();
 		return $this->db->lastInsertId();
 	}
-	
-	public function updateDatabase($array_data, $array_where = 0, $table) {		
+
+	public function updateDatabase($array_data, $array_where, $table) {
 		$query = $this->db->createQueryBuilder()->update($table, 't');
 		foreach($array_data as $key => $value){
 			$query->set('t.'.$key, '?');
 		}
-		if($array_where){			
+		if($array_where){
 			$i = 0;
 			foreach($array_where as $key => $value){
 				if($i == 0){
@@ -48,25 +48,25 @@ class Data {
 					$query->andWhere('t.'.$key.' = ?');
 				}
 				$i++;
-			}	
+			}
 		}
 		$j = 0;
 		foreach($array_data as $key => $value){
 			$query->setParameter($j, $value);
 			$j++;
 		}
-		if($array_where){		
+		if($array_where){
 			foreach($array_where as $key => $value){
 				$query->setParameter($j, $value);
 				$j++;
-			}	
+			}
 		}
 		$query->execute();
 	}
-	
-	public function deleteEntry($array_where = 0, $table) {		
+
+	public function deleteEntry($array_where, $table) {
 		$query = $this->db->createQueryBuilder()->delete($table);
-		if($array_where){			
+		if ($array_where) {
 			$i = 0;
 			foreach($array_where as $key => $value){
 				if($i > 0){

--- a/Project/CMS/Libraries/Classes/Container/View.php
+++ b/Project/CMS/Libraries/Classes/Container/View.php
@@ -102,7 +102,6 @@ class View {
         extract($this->data);
         mb_internal_encoding('UTF-8');
 		mb_http_output('UTF-8');
-		mb_http_input('UTF-8');
 		mb_language('uni');
 		mb_regex_encoding('UTF-8');
 		ob_start('mb_output_handler');

--- a/Project/CMS/Libraries/Classes/Extended/Form.php
+++ b/Project/CMS/Libraries/Classes/Extended/Form.php
@@ -246,7 +246,7 @@ class Form extends Standard {
 		return $container;
 	}
 	
-	public function gen_menStruc($al_shortcut_multiple = null, $module, $required) {
+	public function gen_menStruc($al_shortcut_multiple, $module, $required) {
 		$al_shortcut_multiple = isset($al_shortcut_multiple) ? $al_shortcut_multiple : array(); 
 		$al_fetch_section_names = 
 			$this->data->getData(

--- a/Project/CMS/index.php
+++ b/Project/CMS/index.php
@@ -13,7 +13,7 @@ if (file_exists('config.php')) {
 
 if(!empty($timezone)){ date_default_timezone_set($timezone); }
 $session_domain = !empty($session_domain) ? $session_domain : $_SERVER['SERVER_NAME'];
-$session_time = !empty($session_time) ? $session_time : '0';
+$session_time = !empty($session_time) ? (int)$session_time : 0;
 $session_path = !empty($session_path) ? $session_path : '/';
 session_set_cookie_params($session_time, $session_path, $session_domain);
 session_start();

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     
     "require": {
-		"doctrine/dbal": "2.5.1",
+		"doctrine/dbal": "^2.13",
 		"phpmailer/phpmailer": "~6.1"
     },
     


### PR DESCRIPTION
- [PHP 8+ - It doesn't like to have functions with required arguments after optional ones](https://github.com/quartzcms/Quartz-CMS/commit/6852a6c75f6821bfda266c048baa3a0830571845) - More info: https://php.watch/versions/8.0/deprecate-required-param-after-optional.
- [Use at least dbal v2.13 to be compatible with PHP 8 as there were an issue with a types being incompatible with the method signature](https://github.com/quartzcms/Quartz-CMS/commit/5c20eef70ea7f8db758bd086f432ab73d8e61af3)
- [Remove unnecessary mb_http_input(UTF-8) which had an invalid value](https://github.com/quartzcms/Quartz-CMS/pull/1/commits/88266578d2b85ecfad4f136c1337f31c9d841813). `mb_http_input()` is used to get the input encoding, but not to set one. Passing an encoding to it doesn't make sense.
- [PHP-8 Fix incorrect argument given for `session_set_cookie_param`](https://github.com/quartzcms/Quartz-CMS/pull/1/commits/2e6b2e566fdd5aea8f8f55a30db20800d82aacbe). [`lifetime`](https://www.php.net/manual/en/function.session-set-cookie-params.php)'s first argument must be an integer. String was given.

Hope it helps @quartzcms! 😊

Good luck 🎉